### PR TITLE
Add support for Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
 		}
 	],
 	"require": {
-		"illuminate/support": "^6|^7|^8",
-		"illuminate/cache": "^6|^7|^8"
+		"illuminate/support": "^6|^7|^8|^9",
+		"illuminate/cache": "^6|^7|^8|^9"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9.3",
-		"orchestra/testbench": "^6.3"
+		"orchestra/testbench": "^6.0|^7.7"
 	},
 	"autoload": {
 		"psr-4": {
@@ -44,7 +44,7 @@
 			]
 		},
 		"branch-alias": {
-			"dev-master": "1.0-dev"
+			"dev-master": "2.0-dev"
 		}
 	}
 }


### PR DESCRIPTION
Adding support to allow the package to run in Laravel 9 projects.
Orchestra test bench needs an upgrade as well to work with L9.